### PR TITLE
Fixed the blocked title text on the drawing(main) page

### DIFF
--- a/app/src/main/res/layout/activity_drawing.xml
+++ b/app/src/main/res/layout/activity_drawing.xml
@@ -23,9 +23,10 @@
 
             <TextView
                 android:id="@+id/drawing_toolbar_textView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:maxLines="2"
+                android:autoSizeTextType="uniform"
                 android:onClick="onProjectTitleClicked"
                 android:textAppearance="@style/TextTheme"
                 android:textColor="?android:textColorPrimary" />


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #26, and I have fixed the blocked title text on the drawing(main) page. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/130459191-b403181b-1f62-4822-a560-535e6db58482.png" alt="copy" width="250"/>

Thanks again! Have a nice day! :)