### PR TITLE
Improved display of the color picker

### DIFF
--- a/app/src/main/java/com/benny/pxerstudio/colorpicker/HueSeekBar.java
+++ b/app/src/main/java/com/benny/pxerstudio/colorpicker/HueSeekBar.java
@@ -91,8 +91,7 @@ public class HueSeekBar extends AppCompatSeekBar {
 
             @Override
             public void draw(Canvas canvas) {
-                if (hueBitmap != null)
-                    canvas.drawBitmap(hueBitmap, null, getBounds(), null);
+                canvas.drawBitmap(hueBitmap, null, getBounds(), null);
             }
 
             @Override
@@ -113,22 +112,25 @@ public class HueSeekBar extends AppCompatSeekBar {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-
-        hueBitmap = getHueBitmap();
+        computeHueBitmap();
         invalidate();
     }
 
-    public Bitmap getHueBitmap() {
+    /**
+     * Computes a bitmap with a gradient of hues from 0 to 360 degrees.
+     */
+    public void computeHueBitmap() {
         int width = getWidth();
         int height = getHeight();
 
-        Bitmap hueBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
+        hueBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
 
         for (int x = 0; x < width; x++) {
             float hue = 0;
             if (width > height) {
                 hue = x * 360f / width;
             }
+
             for (int y = 0; y < height; y++) {
                 if (width <= height) {
                     hue = y * 360f / height;
@@ -139,7 +141,5 @@ public class HueSeekBar extends AppCompatSeekBar {
                 hueBitmap.setPixel(x, y, Color.HSVToColor(hsv));
             }
         }
-
-        return hueBitmap;
     }
 }

--- a/app/src/main/java/com/benny/pxerstudio/widget/BorderFab.java
+++ b/app/src/main/java/com/benny/pxerstudio/widget/BorderFab.java
@@ -11,6 +11,7 @@ import android.util.AttributeSet;
 
 import com.benny.pxerstudio.R;
 import com.benny.pxerstudio.util.ContextKt;
+import androidx.core.graphics.ColorUtils;
 import com.github.clans.fab.FloatingActionButton;
 
 /**
@@ -18,15 +19,14 @@ import com.github.clans.fab.FloatingActionButton;
  */
 
 public class BorderFab extends FloatingActionButton {
-    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
-    Paint colorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-    float three, one;
-    Path path = new Path();
-    Rect rect = new Rect(0, 0, getWidth(), getHeight());
+    private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint colorPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Bitmap backgroundBitmap;
 
-    Bitmap bg;
+    private float three, one;
+    private Path path = new Path();
 
-    int color;
+    private int color;
 
     public BorderFab(Context context) {
         super(context);
@@ -49,11 +49,6 @@ public class BorderFab extends FloatingActionButton {
     }
 
     private void init() {
-        bg = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888);
-        bg.eraseColor(Color.WHITE);
-        bg.setPixel(0, 0, Color.GRAY);
-        bg.setPixel(1, 1, Color.GRAY);
-
         three = ContextKt.convertDpToPixel(getContext(), 2);
         one = ContextKt.convertDpToPixel(getContext(), 1);
 
@@ -65,7 +60,6 @@ public class BorderFab extends FloatingActionButton {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        colorPaint.setColor(Color.WHITE);
 
         final int width = getWidth();
         final int height = getHeight();
@@ -73,11 +67,39 @@ public class BorderFab extends FloatingActionButton {
         canvas.save();
         path.addCircle(width / 2f, height / 2f, width / 3f + one, Path.Direction.CCW);
         canvas.clipPath(path);
-        canvas.drawBitmap(bg, null, rect, colorPaint);
+        canvas.drawBitmap(backgroundBitmap, null, new Rect(0, 0, getWidth(), getHeight()), null);
         canvas.restore();
 
         colorPaint.setColor(color);
         canvas.drawCircle(width / 2f, height / 2f, width / 3f + one, colorPaint);
         canvas.drawCircle(width / 2f, height / 2f, width / 3f + one, paint);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        computeBackgroundBitmap();
+        invalidate();
+    }
+
+    /**
+     * Computes a bitmap with a checkerboard pattern of gray squares.
+     */
+    public void computeBackgroundBitmap() {
+        int width = getWidth() / 10;
+        int height = getHeight() / 10;
+
+        backgroundBitmap = Bitmap.createBitmap(width * 2, height * 2, Bitmap.Config.ARGB_8888);
+        backgroundBitmap.eraseColor(ColorUtils.setAlphaComponent(Color.GRAY, 200));
+
+        for (int i = 0; i < width; i++) {
+            for (int j = 0; j < height * 2; j++) {
+                if (j % 2 == 0) {
+                    backgroundBitmap.setPixel(i * 2, j, Color.argb(200, 220, 220, 220));
+                } else {
+                    backgroundBitmap.setPixel(i * 2 + 1, j, Color.argb(200, 220, 220, 220));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Hey, I love this app, but I found a few bugs, so I'm made this PR.
I'm not an expert in android development.

## Changes
- the current color is taken into account in the alpha seek bar
- the alpha doesn't affect the saturation selection
- the black color appear on the saturation selection
- the color picker displays the real color, with a grid background and not the background color

## Screenshots Before/After

<img src="https://user-images.githubusercontent.com/23208753/234687561-f47a0a96-f280-42f0-b1ee-bb1448ef717e.jpg" width="40%"/> <img src="https://user-images.githubusercontent.com/23208753/234687568-35423847-cbfa-40bd-a304-97082fdd9257.jpg" width="40%"/>
